### PR TITLE
update whisper warnings

### DIFF
--- a/llmlib/llmlib/whisper.py
+++ b/llmlib/llmlib/whisper.py
@@ -125,7 +125,8 @@ class Whisper:
             kwargs["generate_kwargs"] = {"language": "english"}
         # ignore this warning:
         # .../site-packages/transformers/models/whisper/generation_whisper.py:496: FutureWarning: The input name `inputs` is deprecated. Please make sure to use `input_features` instead.
-        with warnings.catch_warnings(action="ignore", category=FutureWarning):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
             data = self.pipe(
                 file_or_files,
                 **kwargs,


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/tanalp/toxicainment/llm_app/llmlib/llmlib/whisper.py", line 182, in <module>
    run_whisper_on_saxony()
  File "/home/tanalp/toxicainment/llm_app/llmlib/llmlib/whisper.py", line 175, in run_whisper_on_saxony
    output = whisper.run_pipe(file_or_files=video_files, translate=False)
  File "/home/tanalp/toxicainment/llm_app/llmlib/llmlib/whisper.py", line 135, in run_pipe
    with warnings.catch_warnings(action="ignore", category=FutureWarning):
TypeError: catch_warnings.__init__() got an unexpected keyword argument 'action'

It was a fix for this issue, otherwise I was not able to run run_pipe inside run_whisper_on_saxony() which was only intended to get saxony data, read prompt, transcribe using run_pipe and then concat prompt and transcriptions.